### PR TITLE
tags: show in blog page

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -26,7 +26,14 @@
                                     <header class="major">
                                         <h3>{{ post.title }}</h3>
                                     </header>
-                                    <p>
+                                    <span>
+                                         {% for tag in post.tags %}
+                                         {% capture tag_name %}{{ tag }}{% endcapture %}
+                                         <div class="icon fa fa-tag fa-xs"></div>
+                                         <a href="/tag/{{ tag_name }}" class="icon" style="font-size: 1em"><code><nobr>{{ tag_name }}</nobr></code>&nbsp;</a>
+                                         {% endfor %}
+                                         </span>
+                                    <p style="padding-top: 20px">
                                         {{ post.description }}
                                     </p>
                                     <ul class="actions">


### PR DESCRIPTION
this adds support for showing tags in the /blog page, which makes it
easier to follow a post's tags without having to open the post